### PR TITLE
Fixing class completion in function parameters

### DIFF
--- a/olympic_funcs.py
+++ b/olympic_funcs.py
@@ -390,6 +390,15 @@ class GenListener(sublime_plugin.EventListener):
 				text_sel = view.line(sel)
 				text = view.substr(text_sel)
 				text = text.rstrip().lstrip()
+				if view.match_selector(view.sel()[0].a, 'meta.function.parameters.c++'):
+					reg = "[ ,(]"
+					match = re.search(reg, text[-1::-1])
+					text = text[-match.start():]
+					# print (text)
+					reg = "[ ,)]"
+					match = re.search(reg, text)
+					text = text[:match.start()]
+					# print (text)
 				if pregen_class(text) is None:
 					return ('insert_best_completion', {'exact': False, 'default': '\t'})
 			# elif args['action'] == 'gen_def':


### PR DESCRIPTION
When declaring inside function parameters, class completions didn't work even with shift+tab if it's not the best completion. I have tried to fix this.
Before:
![before](https://user-images.githubusercontent.com/26321479/39587290-f46d870e-4f1a-11e8-9e0b-df46a1652f83.gif)
After:
![after](https://user-images.githubusercontent.com/26321479/39587298-fc334604-4f1a-11e8-9394-b110de446230.gif)
