### PR TITLE
Closing sidebar

### DIFF
--- a/FastOlympicCoding (Linux).sublime-settings
+++ b/FastOlympicCoding (Linux).sublime-settings
@@ -82,5 +82,8 @@
 		"dont_expand": [
 			"pii"
 		]
-	}
+	},
+
+	// closing sidebar when executing
+	"close_sidebar": true
 }

--- a/FastOlympicCoding (OSX).sublime-settings
+++ b/FastOlympicCoding (OSX).sublime-settings
@@ -83,5 +83,8 @@
 		"dont_expand": [
 			"pii"
 		]
-	}
+	},
+
+	// closing sidebar when executing
+	"close_sidebar": true
 }

--- a/FastOlympicCoding (Windows).sublime-settings
+++ b/FastOlympicCoding (Windows).sublime-settings
@@ -82,5 +82,8 @@
 		"dont_expand": [
 			"pii"
 		]
-	}
+	},
+
+	// closing sidebar when executing
+	"close_sidebar": true
 }

--- a/test_manager.py
+++ b/test_manager.py
@@ -1430,11 +1430,12 @@ class ViewTesterCommand(sublime_plugin.TextCommand):
 			self.tied_dbg = dbg_view
 			self.have_tied_dbg = True
 			create_new = True
-			try:
-				sublime.set_timeout_async(lambda window=window: window.set_sidebar_visible(False), 50)
-			except:
-				# Version of sublime text < 3102
-				pass
+			if get_settings().get('close_sidebar'):
+				try:
+					sublime.set_timeout_async(lambda window=window: window.set_sidebar_visible(False), 50)
+				except:
+					# Version of sublime text < 3102
+					pass
 			dbg_view.run_command('toggle_setting', {'setting': 'word_wrap'})
 
 		if len(window.get_layout()['cols']) != 3 or window.get_layout()['cols'][1] >= 0.89:


### PR DESCRIPTION
_[small PR]_

Hello!
When I first installed the plugin, I had a problem with the sidebar: it closes every time you run the program. With all folders and files to navigate... It is very inconvenient to open the sidebar again every time - I disabled this function. But I do not exclude the possibility that it is convenient for someone.

Therefore, I suggest creating a `close_sidebar` setting.