### PR TITLE
Save tests to separate dir

### DIFF
--- a/ContestHandler.py
+++ b/ContestHandler.py
@@ -11,6 +11,7 @@ from sublime import Region
 
 handlers = [codeforces]
 
+
 class ContestHandlerCommand(sublime_plugin.TextCommand):
 	def create_path(self, base, _path):
 		for i in range(len(_path)):
@@ -36,9 +37,9 @@ class ContestHandlerCommand(sublime_plugin.TextCommand):
 					'test': inputs[i],
 					'correct_answers': [outputs[i]]
 				})
-			file = open(file_name + (get_settings().get('tests_file_suffix') or TestManagerCommand.TESTS_FILE_SUFFIX), 'w')
-			file.write(sublime.encode_value(tests, True))
-			file.close()
+			with open(TestManagerCommand.get_tests_file_path(file_name), 'w') as f:
+				f.write(sublime.encode_value(tests, True))
+
 			def go(self=self, handler=handler, contest_id=contest_id, base=base, pid=self.next_problem(pid)):
 				self.init_problems(handler, contest_id, base, pid=pid)
 			sublime.set_timeout_async(go)

--- a/ContestHandler.py
+++ b/ContestHandler.py
@@ -8,6 +8,7 @@ except ImportError:
 	pass
 from .test_manager import TestManagerCommand
 from sublime import Region
+from .settings import get_tests_file_path
 
 handlers = [codeforces]
 
@@ -37,11 +38,13 @@ class ContestHandlerCommand(sublime_plugin.TextCommand):
 					'test': inputs[i],
 					'correct_answers': [outputs[i]]
 				})
-			with open(TestManagerCommand.get_tests_file_path(file_name), 'w') as f:
+
+			with open(get_tests_file_path(file_name), 'w') as f:
 				f.write(sublime.encode_value(tests, True))
 
 			def go(self=self, handler=handler, contest_id=contest_id, base=base, pid=self.next_problem(pid)):
 				self.init_problems(handler, contest_id, base, pid=pid)
+
 			sublime.set_timeout_async(go)
 		else:
 			if len(pid) == 1:

--- a/FastOlympicCoding (Linux).sublime-settings
+++ b/FastOlympicCoding (Linux).sublime-settings
@@ -99,5 +99,5 @@
 	"close_sidebar": true, 
 
 	// tests files dir
-	"tests_dir": ".tests"
+	"tests_relative_dir": ""
 }

--- a/FastOlympicCoding (Linux).sublime-settings
+++ b/FastOlympicCoding (Linux).sublime-settings
@@ -96,9 +96,8 @@
 	},
 
 	// closing sidebar when executing
-	"close_sidebar": false, 
+	"close_sidebar": true, 
 
 	// tests files dir
-	// "" if none
 	"tests_dir": ".tests"
 }

--- a/FastOlympicCoding (Linux).sublime-settings
+++ b/FastOlympicCoding (Linux).sublime-settings
@@ -96,5 +96,9 @@
 	},
 
 	// closing sidebar when executing
-	"close_sidebar": true
+	"close_sidebar": false, 
+
+	// tests files dir
+	// "" if none
+	"tests_dir": ".tests"
 }

--- a/FastOlympicCoding (OSX).sublime-settings
+++ b/FastOlympicCoding (OSX).sublime-settings
@@ -97,5 +97,8 @@
 	},
 
 	// closing sidebar when executing
-	"close_sidebar": true
+	"close_sidebar": true, 
+
+	// tests files dir
+	"tests_dir": ".tests"
 }

--- a/FastOlympicCoding (OSX).sublime-settings
+++ b/FastOlympicCoding (OSX).sublime-settings
@@ -100,5 +100,5 @@
 	"close_sidebar": true, 
 
 	// tests files dir
-	"tests_dir": ".tests"
+	"tests_relative_dir": ""
 }

--- a/FastOlympicCoding (Windows).sublime-settings
+++ b/FastOlympicCoding (Windows).sublime-settings
@@ -99,5 +99,5 @@
 	"close_sidebar": true, 
 
 	// tests files dir
-	"tests_dir": ".tests"
+	"tests_relative_dir": ""
 }

--- a/FastOlympicCoding (Windows).sublime-settings
+++ b/FastOlympicCoding (Windows).sublime-settings
@@ -96,5 +96,8 @@
 	},
 
 	// closing sidebar when executing
-	"close_sidebar": true
+	"close_sidebar": true, 
+
+	// tests files dir
+	"tests_dir": ".tests"
 }

--- a/settings.py
+++ b/settings.py
@@ -13,7 +13,7 @@ default_settings_file = 'FastOlympicCoding ({os}).sublime-settings'.format(
 )
 
 tests_file_suffix = ':tests'
-tests_dir = ''
+tests_relative_dir = ''
 
 settings = {}
 run_supported_exts = set()
@@ -61,8 +61,8 @@ def get_tests_file_suffix():
 	return get_settings().get('tests_file_suffix') or tests_file_suffix
 
 def get_tests_file_path(file):
-	tests_dir = get_settings().get('tests_dir') or tests_dir
-	dirname = os.path.join(os.path.dirname(file), tests_dir)
+	dirname = os.path.join(os.path.dirname(file),
+		get_settings().get('tests_relative_dir') or tests_relative_dir)
 
 	if not os.path.exists(dirname):
 		os.makedirs(dirname)

--- a/settings.py
+++ b/settings.py
@@ -1,5 +1,6 @@
 import sublime
 from os import path
+import os
 
 
 root_dir = path.split(__file__)[0]
@@ -10,6 +11,9 @@ settings_file = 'FastOlympicCoding.sublime-settings'
 default_settings_file = 'FastOlympicCoding ({os}).sublime-settings'.format(
 	os={ 'windows': 'Windows', 'linux': 'Linux', 'osx': 'OSX' }[sublime.platform().lower()]
 )
+
+tests_file_suffix = ':tests'
+tests_dir = ''
 
 settings = {}
 run_supported_exts = set()
@@ -52,3 +56,17 @@ def try_load_settings():
 
 def plugin_loaded():
 	sublime.set_timeout(try_load_settings, 200)
+
+def get_tests_file_suffix():
+	return get_settings().get('tests_file_suffix') or tests_file_suffix
+
+def get_tests_file_path(file):
+	tests_dir = get_settings().get('tests_dir') or tests_dir
+	dirname = os.path.join(os.path.dirname(file), tests_dir)
+
+	if not os.path.exists(dirname):
+		os.makedirs(dirname)
+
+	filename = os.path.basename(file) + get_tests_file_suffix()
+	
+	return os.path.join(dirname, filename)

--- a/test_manager.py
+++ b/test_manager.py
@@ -12,7 +12,7 @@ from time import time
 import threading
 
 from .Modules.ProcessManager import ProcessManager
-from .settings import base_name, get_settings, root_dir
+from .settings import base_name, get_settings, root_dir, get_tests_file_path
 from .debuggers import debugger_info
 from .ContestHandlers import handler_info
 from .Highlight.CppVarHighlight import highlight
@@ -38,8 +38,6 @@ class TestManagerCommand(sublime_plugin.TextCommand):
 	REGION_LINE_PROP = ['string', 'dot', \
 				sublime.DRAW_NO_FILL | sublime.DRAW_STIPPLED_UNDERLINE | \
 					sublime.DRAW_NO_OUTLINE | sublime.DRAW_EMPTY_AS_OVERWRITE]
-	TESTS_FILE_SUFFIX = ':tests'
-	TESTS_DIR = ''
 
 	# Test
 	# REGION_POS_PROP = REGION_UNKNOWN_PROP
@@ -385,20 +383,6 @@ class TestManagerCommand(sublime_plugin.TextCommand):
 		def terminate(self):
 			self.process_manager.terminate()
 
-	def get_tests_file_suffix(self):
-		return get_settings().get('tests_file_suffix') or self.TESTS_FILE_SUFFIX
-	
-	def get_tests_file_path(self, file):
-		tests_dir = get_settings().get('tests_dir') or self.TESTS_DIR
-		dirname = os.path.join(os.path.dirname(file), tests_dir)
-
-		if not os.path.exists(dirname):
-			os.makedirs(dirname)
-
-		filename = os.path.basename(file) + self.get_tests_file_suffix()
-		
-		return os.path.join(dirname, filename)
-
 	def insert_text(self, edit, text=None):
 		v = self.view
 		expected = v.line(self.delta_input).end()
@@ -664,7 +648,7 @@ class TestManagerCommand(sublime_plugin.TextCommand):
 			# self.fold_accept_tests()
 	
 	def memorize_tests(self):
-		with open(self.get_tests_file_path(self.dbg_file), 'w') as f:
+		with open(get_tests_file_path(self.dbg_file), 'w') as f:
 			f.write(sublime.encode_value([x.memorize() for x in (self.tester.get_tests())], True))
 
 	def on_insert(self, s):
@@ -955,12 +939,12 @@ class TestManagerCommand(sublime_plugin.TextCommand):
 
 		if not clr_tests:
 			try:
-				with open(self.get_tests_file_path(run_file)) as f:
+				with open(get_tests_file_path(run_file)) as f:
 					tests = [self.Test(x) for x in sublime.decode_value(f.read()) if x['test'].strip()]
 			except:
 				tests = []
 		else:
-			with open(self.get_tests_file_path(run_file), 'w') as f:
+			with open(get_tests_file_path(run_file), 'w') as f:
 				f.write('[]')
 			tests = []
 		file_ext = path.splitext(run_file)[1][1:]


### PR DESCRIPTION
Added option to save `:tests` files to a separate dir 
(saves to `.tests` by default)