### PR TITLE
Bug fix - filename with bracket not able to compile

### DIFF
--- a/FastOlympicCoding (Linux).sublime-settings
+++ b/FastOlympicCoding (Linux).sublime-settings
@@ -18,7 +18,7 @@
 		{
 			"name": "C++",
 			"extensions": ["cpp"],
-			"compile_cmd": "g++ '{source_file}' -std=gnu++11 -o {file_name}",
+			"compile_cmd": "g++ '{source_file}' -std=gnu++11 -o '{file_name}'",
 			"run_cmd": "./\"{file_name}\" {args} -debug",
 
 			"lint_compile_cmd": "g++ -std=gnu++11 '{source_file}' -I '{source_file_dir}'"

--- a/FastOlympicCoding (OSX).sublime-settings
+++ b/FastOlympicCoding (OSX).sublime-settings
@@ -19,7 +19,7 @@
 		{
 			"name": "C++",
 			"extensions": ["cpp"],
-			"compile_cmd": "g++ '{source_file}' -std=gnu++11 -o {file_name}",
+			"compile_cmd": "g++ '{source_file}' -std=gnu++11 -o '{file_name}'",
 			"run_cmd": "./\"{file_name}\" {args} -debug",
 
 			"lint_compile_cmd": "g++ -std=gnu++11 '{source_file}' -I '{source_file_dir}'"


### PR DESCRIPTION
use '{file}' instead, which properly encapsulates the file name with brackets